### PR TITLE
Used real time timestamp for meter readings generation

### DIFF
--- a/src/readings/readings.data.js
+++ b/src/readings/readings.data.js
@@ -1,11 +1,17 @@
 const { meters } = require("../meters/meters");
 
+// Meter Reading
 const maxMeterReading= 2    // Max Power Usage by any Meter
 const maxDataCount= 20 // Max Number of Data Points for a Meter Reading
 
+// Time
 const hour = 3600; // Seconds in a Hour
-const startTime = 1607686125; // Friday, 11 December 2020 11:28:45 GMT+00:00
+//@deprecated: Replaced Original Time Stamp usd for testing : 1607686125 with real time value
+const originalTimeStamp = new Date("Friday, 11 December 2020 11:28:45 GMT+00:00") 
+const startTime =  Date.now()  // real time data
+console.log("Using Start Time: "+ new Date(startTime))
 
+// Original Value used Real time now
 /**
  * Generates random meter readings in range (0, maxDataCount] with each data point contain:
  * Power usage(kW): meter reading between(0, maxMeterReading) 
@@ -14,7 +20,6 @@ const startTime = 1607686125; // Friday, 11 December 2020 11:28:45 GMT+00:00
  */
 const generateSingle = () => {
     const readingsLength = Math.ceil(Math.random() * maxDataCount); 
-
     return [...new Array(readingsLength)].map((reading, index) => ({
         time: startTime - index * hour,
         reading: Math.random() * maxMeterReading,


### PR DESCRIPTION
## Used real-world time for generation of data

CHANGELOG
-  Used `Date.now()`  instead of hardcoded time `Friday, 11 December 2020 11:28:45 GMT+00:00`  timestamp for generation of all meter readings


Isse: None